### PR TITLE
fix(farmshops): strict NO county/municipality filtering

### DIFF
--- a/docs/gardsbutikker.html
+++ b/docs/gardsbutikker.html
@@ -119,6 +119,6 @@
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js"></script>
-  <script src="js/gardsbutikker.js?v=20260221h"></script>
+  <script src="js/gardsbutikker.js?v=20260221i"></script>
 </body>
 </html>

--- a/docs/js/gardsbutikker.js
+++ b/docs/js/gardsbutikker.js
@@ -2084,24 +2084,29 @@ out center tags 150;
     if (regionValue || municipalityValue) {
       filtered = filtered.filter((shop) => {
         const regionMatch = !regionValue || (countryCode === 'NO'
-          ? (!hasRegionDataForCountry || !(shop.region || '').toString().trim() || regionMatches(shop.region || '', regionTerms))
+          ? regionMatches(shop.region || '', regionTerms)
           : normalizeAdminLabel(shop.region || '') === normalizeAdminLabel(regionValue || regionText));
         const municipalityMatch = !municipalityValue || (countryCode === 'NO'
-          ? (!hasMunicipalityDataForCountry || !(shop.municipality || '').toString().trim() || municipalityMatches(shop.municipality || '', municipalityTerms))
+          ? municipalityMatches(shop.municipality || '', municipalityTerms)
           : shop.municipality === municipalityValue);
         return regionMatch && municipalityMatch;
       });
     }
 
     if (countryCode === 'NO' && (regionValue || municipalityValue) && (!hasRegionDataForCountry || !hasMunicipalityDataForCountry)) {
-      setMapStatus('Datagrunnlaget mangler fylke/kommune på mange treff; viser tilgjengelige butikker i valgt land/område.');
+      setMapStatus('Datagrunnlaget mangler fylke/kommune på mange treff; bruker kun verifiserte treff for valgt område.');
     }
 
     if (countryCode && !filtered.length) {
-      const countrySeeds = getTrustedSeedCandidates(countryCode, countryText || countryNameByCode(countryCode), '', '');
+      const countrySeeds = getTrustedSeedCandidates(
+        countryCode,
+        countryText || countryNameByCode(countryCode),
+        municipalityText,
+        regionText,
+      );
       if (countrySeeds.length) {
         filtered = mergeShopLists(filtered, countrySeeds);
-        setMapStatus('Viser kvalitetssikrede land-seeds (fallback).');
+        setMapStatus('Viser kvalitetssikrede, verifiserte treff for valgt område (seed-fallback).');
       }
     }
 
@@ -2115,7 +2120,7 @@ out center tags 150;
       );
     }
 
-    if (countryCode && !filtered.length) {
+    if (countryCode && !regionValue && !municipalityValue && !query && !filtered.length) {
       const relaxedCountryOnly = shops.filter((shop) => shopMatchesCountryRelaxed(shop, countryCode));
       if (relaxedCountryOnly.length) {
         filtered = relaxedCountryOnly;


### PR DESCRIPTION
Strammer Norge-filter slik at valgt fylke/kommune ikke lenger faller tilbake til alle landtreff.\n\n- Strengt region/kommune-filter når valgt\n- Ingen bred land-fallback når region/kommune/query er aktiv\n- Seed-fallback scoped til valgt område\n- Cache-bust til v=20260221i