### PR TITLE
fix(farmshops): avoid generic seed override for specific NO filters

### DIFF
--- a/docs/gardsbutikker.html
+++ b/docs/gardsbutikker.html
@@ -119,6 +119,6 @@
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js"></script>
-  <script src="js/gardsbutikker.js?v=20260221i"></script>
+  <script src="js/gardsbutikker.js?v=20260221j"></script>
 </body>
 </html>

--- a/docs/js/gardsbutikker.js
+++ b/docs/js/gardsbutikker.js
@@ -1492,15 +1492,21 @@
     if (!filtered.length) {
       const selectedCountryCode = resolveCountryCode(countrySelect.value) || normalizeCountryCode(selectedText(countrySelect));
       const selectedCountryLabel = selectedText(countrySelect) || countryNameByCode(selectedCountryCode);
+      const selectedRegionValue = regionSelect?.value || '';
+      const selectedMunicipalityValue = muniSelect?.value || '';
+      const selectedRegionLabel = selectedRegionValue ? selectedText(regionSelect) : '';
+      const selectedMunicipalityLabel = selectedMunicipalityValue ? selectedText(muniSelect) : '';
+      const selectedQuery = (searchInput?.value || '').trim();
       const hasActiveFilters = Boolean(
         selectedCountryCode ||
-        (searchInput?.value || '').trim() ||
-        regionSelect?.value ||
-        muniSelect?.value
+        selectedQuery ||
+        selectedRegionValue ||
+        selectedMunicipalityValue
       );
+      const hasSpecificAreaFilter = Boolean(selectedQuery || selectedRegionValue || selectedMunicipalityValue);
 
-      if (hasActiveFilters && selectedCountryCode) {
-        const emergencySeeds = addDistanceFromUser(getTrustedSeedCandidates(selectedCountryCode, selectedCountryLabel, '', ''));
+      if (hasActiveFilters && selectedCountryCode && !hasSpecificAreaFilter) {
+        const emergencySeeds = addDistanceFromUser(getTrustedSeedCandidates(selectedCountryCode, selectedCountryLabel, selectedMunicipalityLabel, selectedRegionLabel));
         if (emergencySeeds.length) {
           setMapStatus('Viser kvalitetssikrede nød-fallback treff for valgt land.');
           return renderList(emergencySeeds);


### PR DESCRIPTION
## Hva\n- Hindrer nød-fallback fra å vise generiske land-seeds når bruker har valgt spesifikt fylke/kommune/søk\n- Beholder korrekt tomtilstand for valgt filter i stedet for feil treff\n- Oppdaterer script cache-busting til v=20260221j\n\n## Hvorfor\n- Løser feil der resultater så ut som ikke-søkeresultat fordi fallback overstyrte områdevalg.