### PR TITLE
fix: county search runs locality fallback before strict mode

### DIFF
--- a/docs/js/gardsbutikker.js
+++ b/docs/js/gardsbutikker.js
@@ -2189,13 +2189,6 @@ out center tags 150;
     activeFiltered = filtered;
     renderList(filtered);
 
-    if (!ENABLE_LIVE_ENRICHMENT) {
-      if (!filtered.length && countryCode) {
-        setMapStatus('Ingen verifiserte treff i datasett/seed for valgt filter. Bruk Google Maps-søk for utvidet søk.');
-      }
-      return filtered;
-    }
-
     if (!filtered.length && countryCode && (query || municipalityText || regionText)) {
       const localityHint = [query, municipalityText, regionText, countryText]
         .filter(Boolean)
@@ -2244,6 +2237,13 @@ out center tags 150;
       } catch (_) {
         // Ignore fallback failures and continue with web enrichment below.
       }
+    }
+
+    if (!ENABLE_LIVE_ENRICHMENT) {
+      if (!filtered.length && countryCode) {
+        setMapStatus('Ingen verifiserte treff i datasett/seed for valgt filter. Bruk Google Maps-søk for utvidet søk.');
+      }
+      return filtered;
     }
 
     const shouldEnrich = Boolean(


### PR DESCRIPTION
## What\n- move strict-mode (ENABLE_LIVE_ENRICHMENT=false) early return to run after locality fallback\n- keep current strict behavior, but avoid empty county dead-end\n\n## Result\nCounty/city selections can recover with area-based nearby results instead of stopping immediately.