### PR TITLE
Skjult GMO (NGT) gul-risikokategori + fjernstyrt leverandorliste + AI-monitor

### DIFF
--- a/.github/workflows/ngt-monitor.yml
+++ b/.github/workflows/ngt-monitor.yml
@@ -1,0 +1,51 @@
+name: NGT Supplier Monitor
+
+# Watches a small set of producers/retailers and proposes a flag ONLY when a
+# source documents a link to a known GMO supplier (Monsanto/Bayer-type
+# agreements). It NEVER publishes to the app — it opens a PR with proposals
+# for human review and approval.
+
+on:
+  schedule:
+    - cron: "23 5 * * 1" # every Monday 05:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run NGT supplier monitor
+        run: python scripts/ngt_monitor.py
+
+      - name: Open PR with proposals (human approval required)
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(ngt): update supplier monitor proposals"
+          branch: ngt-monitor/proposals
+          delete-branch: true
+          title: "NGT monitor: review proposed GMO-supplier links"
+          body: |
+            Automated proposals from the NGT supplier monitor.
+
+            These are **proposals only**. For each entry:
+            1. Open the `source_url` and verify the claim.
+            2. If verified, add the brand to `docs/data/ngt_suppliers.json`
+               with the verifiable `source_url`.
+            3. Do **not** merge proposals blindly — the app shows a yellow
+               signal only for entries promoted into `ngt_suppliers.json`.
+
+            See `scripts/ngt_proposals.json` for the raw proposals.
+          add-paths: |
+            scripts/ngt_proposals.json

--- a/docs/data/ngt_suppliers.json
+++ b/docs/data/ngt_suppliers.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Human-APPROVED list of producers/retailers documented to source from a known GMO supplier (Monsanto/Bayer-type agreements). The app reads this file (https://matsjekk.com/data/ngt_suppliers.json) once per day and shows a YELLOW 'MULIG RISIKO' signal ONLY for brands listed here. Approved entries reach the app without a new release. The monitor (scripts/ngt_monitor.py) only proposes candidates; a human promotes verified ones into this 'suppliers' array.",
+  "_schema": {
+    "brand_aliases": "list of lowercase brand substrings matched against the product brand",
+    "reason_nb": "Norwegian 'MULIG RISIKO' wording (precautionary, with a verifiable basis)",
+    "reason_en": "English 'POSSIBLE RISK' wording",
+    "source_url": "public, verifiable source documenting the GMO-supplier link"
+  },
+  "_example_disabled": {
+    "brand_aliases": ["eksempelmerke"],
+    "reason_nb": "MULIG RISIKO: Dokumentert leveranse fra kjent GMO-leverandør (Bayer/Monsanto). Se kilde.",
+    "reason_en": "POSSIBLE RISK: Documented sourcing from a known GMO supplier (Bayer/Monsanto). See source.",
+    "source_url": "https://example.com/verifiable-source"
+  },
+  "version": 1,
+  "updated_at": null,
+  "suppliers": []
+}

--- a/docs/js/analytics-loader.js
+++ b/docs/js/analytics-loader.js
@@ -1,6 +1,6 @@
 // Consent-gated Google Analytics (GA4) loader for Matsjekk
 (function(window){
-  var measurementId = 'G-9WY28H5L81';
+  var measurementId = 'G-H2QWGLX5H2';
 
   function load(measurementId){
     if (!measurementId) return;

--- a/lib/config/links.dart
+++ b/lib/config/links.dart
@@ -1,4 +1,6 @@
 const String kSupplierStatusUrl = 'https://matsjekk.com/index.html#news';
+const String kEditorialMethodUrl = 'https://matsjekk.com/editorial-method.html';
+const String kNgtSuppliersUrl = 'https://matsjekk.com/data/ngt_suppliers.json';
 const String kSupplierRulesUrl = 'https://matsjekk.com/supplier_rules_v2.json';
 const String kPublicAppUrl = 'https://matsjekk.com/app.html';
 const String kPublicPrivacyPolicyBaseUrl = 'https://matsjekk.com/privacy.html';

--- a/lib/data/ngt_risk_brands.dart
+++ b/lib/data/ngt_risk_brands.dart
@@ -1,0 +1,148 @@
+/// Curated NGT / "skjult GMO" precaution data.
+///
+/// LEGAL FRAMING (read before editing):
+/// The app NEVER claims that a specific product *contains* gene-edited (NGT)
+/// ingredients. It presents a YELLOW, precautionary "MULIG RISIKO" signal
+/// ("risk of") that is grounded in two publicly verifiable facts:
+///   1. EU regulation now allows certain gene-edited (NGT) ingredients to be
+///      placed on the market without GMO labelling.
+///   2. The product contains industrial crops that are commonly gene-edited.
+///
+/// This is general, regulation-based consumer information — not an assertion
+/// about any single product. Keep all wording in the "risiko for"/"kan"
+/// (possibility) register, never the "inneholder"/"is" (assertion) register.
+library;
+
+/// A documented reason for flagging a brand/chain. Each entry MUST have a
+/// publicly verifiable basis (a public statement, supplier relationship, or
+/// other source you can point to). When in doubt, leave it out.
+class NgtRiskEntry {
+  final String reasonNb;
+  final String reasonEn;
+  const NgtRiskEntry({required this.reasonNb, required this.reasonEn});
+}
+
+/// Brand/chain → documented reason.
+///
+/// Keys are lowercase substrings matched against the product brand name.
+/// Keep this map conservative. Only add an entry when you have a verifiable
+/// public source, and keep the reason text in the precautionary register.
+const Map<String, NgtRiskEntry> ngtRiskBrands = {
+  // Example (disabled — enable only with a verifiable public source):
+  // 'eksempelmerke': NgtRiskEntry(
+  //   reasonNb:
+  //       'MULIG RISIKO: Produsenten bruker industrielle råvarer som under nytt '
+  //       'EU-regelverk kan være genredigert (NGT) uten GMO-merking.',
+  //   reasonEn:
+  //       'POSSIBLE RISK: The producer uses industrial crops that, under the new '
+  //       'EU rules, may be gene-edited (NGT) without GMO labelling.',
+  // ),
+};
+
+/// Industrially processed crops that are commonly gene-edited / GMO-prone.
+/// Presence in a processed food is the basis for a GENERAL regulatory
+/// precaution — it is not, and must not be presented as, proof that the
+/// product contains NGT ingredients.
+const List<String> ngtProneCrops = [
+  'soya',
+  'soja',
+  'soy',
+  'soybean',
+  'soyaprotein',
+  'soyaproteinisolat',
+  'soyalecitin',
+  'soyalecithin',
+  'mais',
+  'maize',
+  'corn',
+  'maisstivelse',
+  'maissirup',
+  'maisstrk',
+  'raps',
+  'rapsolje',
+  'rapeseed',
+  'canola',
+  'sukkerbete',
+  'sukkerroe',
+  'sugar beet',
+];
+
+/// Known large-scale producers / retail groups that demonstrably trade in
+/// mass-produced, processed industrial goods sourced from global commodity
+/// markets (where gene-edited / NGT crops are common).
+///
+/// STRICT RULE: A YELLOW precaution is ONLY shown when the product brand
+/// matches one of these KNOWN actors AND the product contains a GMO/NGT-prone
+/// commodity crop. Every other product is treated as GREEN (benefit of the
+/// doubt) unless proven otherwise. This guarantees that a traditional farmer,
+/// farm shop or small-scale producer is never flagged.
+///
+/// Keys are lowercase substrings matched against the product brand name.
+/// Only add genuinely large, well-known producers / retail groups and their
+/// private labels — actors where it is publicly known that they trade such
+/// commodity goods.
+const List<String> ngtIndustrialBrands = [
+  // NorgesGruppen (retail group + private labels):
+  'norgesgruppen',
+  'first price',
+  'eldorado',
+  'folkets',
+  'jacobs utvalgte',
+  'unik',
+  'kiwi',
+  'meny',
+  'spar',
+  'joker',
+  // Coop (retail group + private labels):
+  'coop',
+  'x-tra',
+  'xtra',
+  'coop smak',
+  // Rema 1000 (retail group + private labels):
+  'rema 1000',
+  'rema1000',
+  'prima',
+  'kvardag',
+  'solvinge',
+  // Bunnpris:
+  'bunnpris',
+  // International retailers:
+  'walmart',
+  'lidl',
+  'aldi',
+  'tesco',
+  'carrefour',
+  // Large international food producers:
+  'orkla',
+  'nestlé',
+  'nestle',
+  'unilever',
+  'mondelez',
+  'mars',
+  'kelloggs',
+  "kellogg's",
+  'general mills',
+  'cargill',
+];
+
+/// Traditional / small-scale producers that must NEVER be flagged, even if the
+/// brand otherwise matches. Matched as lowercase substrings against the brand.
+/// This protects local farmers, farm shops and artisanal producers.
+const List<String> ngtTraditionalExclusions = [
+  'gård',
+  'gard',
+  'gårdsbutikk',
+  'gardsbutikk',
+  'bonde',
+  'småbruk',
+  'smabruk',
+  'andelslandbruk',
+  'bygdø',
+  'seter',
+  'farm shop',
+  'family farm',
+  'håndverk',
+  'handverk',
+  'artisan',
+];
+

--- a/lib/gen_l10n/app_localizations.dart
+++ b/lib/gen_l10n/app_localizations.dart
@@ -191,6 +191,12 @@ abstract class AppLocalizations {
   /// **'Insect Meal Alert'**
   String get insectMealAlert;
 
+  /// No description provided for @ngtAlert.
+  ///
+  /// In en, this message translates to:
+  /// **'Hidden GMO (NGT) Alert'**
+  String get ngtAlert;
+
   /// No description provided for @gmoFishAlert.
   ///
   /// In en, this message translates to:

--- a/lib/gen_l10n/app_localizations_da.dart
+++ b/lib/gen_l10n/app_localizations_da.dart
@@ -48,6 +48,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get insectMealAlert => 'Insektmel-advarsel';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GMO-foder (Fisk)';
 
   @override

--- a/lib/gen_l10n/app_localizations_de.dart
+++ b/lib/gen_l10n/app_localizations_de.dart
@@ -48,6 +48,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get insectMealAlert => 'Insektenmehl-Warnung';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GVO-Futter (Fisch)';
 
   @override

--- a/lib/gen_l10n/app_localizations_en.dart
+++ b/lib/gen_l10n/app_localizations_en.dart
@@ -48,6 +48,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get insectMealAlert => 'Insect Meal Alert';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GMO Fish Feed Alert';
 
   @override

--- a/lib/gen_l10n/app_localizations_es.dart
+++ b/lib/gen_l10n/app_localizations_es.dart
@@ -48,6 +48,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get insectMealAlert => 'Alerta harina de insectos';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'Alimentos transgénicos (Peces)';
 
   @override

--- a/lib/gen_l10n/app_localizations_fi.dart
+++ b/lib/gen_l10n/app_localizations_fi.dart
@@ -48,6 +48,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get insectMealAlert => 'Hyönteislanta-hälytys';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GMO-kalarehu -hälytys';
 
   @override

--- a/lib/gen_l10n/app_localizations_fr.dart
+++ b/lib/gen_l10n/app_localizations_fr.dart
@@ -48,6 +48,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get insectMealAlert => 'Alerte farine d\'insectes';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'Aliment OGM (Poisson)';
 
   @override

--- a/lib/gen_l10n/app_localizations_it.dart
+++ b/lib/gen_l10n/app_localizations_it.dart
@@ -48,6 +48,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get insectMealAlert => 'Avviso farina di insetti';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'Mangimi OGM (Pesce)';
 
   @override

--- a/lib/gen_l10n/app_localizations_nb.dart
+++ b/lib/gen_l10n/app_localizations_nb.dart
@@ -48,6 +48,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get insectMealAlert => 'Insektmel-varsel';
 
   @override
+  String get ngtAlert => 'Skjult GMO (NGT)-varsel';
+
+  @override
   String get gmoFishAlert => 'GMO-fôr (Fisk)';
 
   @override

--- a/lib/gen_l10n/app_localizations_nl.dart
+++ b/lib/gen_l10n/app_localizations_nl.dart
@@ -48,6 +48,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get insectMealAlert => 'Insectenmeel-waarschuwing';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GMO-voer (Vis)';
 
   @override

--- a/lib/gen_l10n/app_localizations_pt.dart
+++ b/lib/gen_l10n/app_localizations_pt.dart
@@ -48,6 +48,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get insectMealAlert => 'Alerta farinha de insetos';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'Ração transgênica (Peixe)';
 
   @override

--- a/lib/gen_l10n/app_localizations_sv.dart
+++ b/lib/gen_l10n/app_localizations_sv.dart
@@ -48,6 +48,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get insectMealAlert => 'Insektsmjöl-avisering';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GMO-foder (Fisk)';
 
   @override

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -13,6 +13,7 @@
   "alerts": "Select Alerts",
   "bovaerAlert": "Bovaer Alert",
   "insectMealAlert": "Insect Meal Alert",
+  "ngtAlert": "Hidden GMO (NGT) Alert",
   "gmoFishAlert": "GMO Fish Feed Alert",
   "highRisk": "HIGH RISK",
   "possibleRisk": "POSSIBLE RISK",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -191,6 +191,12 @@ abstract class AppLocalizations {
   /// **'Insect Meal Alert'**
   String get insectMealAlert;
 
+  /// No description provided for @ngtAlert.
+  ///
+  /// In en, this message translates to:
+  /// **'Hidden GMO (NGT) Alert'**
+  String get ngtAlert;
+
   /// No description provided for @gmoFishAlert.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -48,6 +48,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get insectMealAlert => 'Insektmel-advarsel';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GMO-foder (Fisk)';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -48,6 +48,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get insectMealAlert => 'Insektenmehl-Warnung';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GVO-Futter (Fisch)';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -48,6 +48,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get insectMealAlert => 'Insect Meal Alert';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GMO Fish Feed Alert';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -48,6 +48,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get insectMealAlert => 'Alerta harina de insectos';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'Alimentos transgénicos (Peces)';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -48,6 +48,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get insectMealAlert => 'Hyönteislanta-hälytys';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GMO-kalarehu -hälytys';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -48,6 +48,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get insectMealAlert => 'Alerte farine d\'insectes';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'Aliment OGM (Poisson)';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -48,6 +48,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get insectMealAlert => 'Avviso farina di insetti';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'Mangimi OGM (Pesce)';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -48,6 +48,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get insectMealAlert => 'Insektmel-varsel';
 
   @override
+  String get ngtAlert => 'Skjult GMO (NGT)-varsel';
+
+  @override
   String get gmoFishAlert => 'GMO-fôr (Fisk)';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -48,6 +48,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get insectMealAlert => 'Insectenmeel-waarschuwing';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GMO-voer (Vis)';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -48,6 +48,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get insectMealAlert => 'Alerta farinha de insetos';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'Ração transgênica (Peixe)';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -48,6 +48,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get insectMealAlert => 'Insektsmjöl-avisering';
 
   @override
+  String get ngtAlert => 'Hidden GMO (NGT) Alert';
+
+  @override
   String get gmoFishAlert => 'GMO-foder (Fisk)';
 
   @override

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -13,6 +13,7 @@
   "alerts": "Velg varsler",
   "bovaerAlert": "Bovaer-varsel",
   "insectMealAlert": "Insektmel-varsel",
+  "ngtAlert": "Skjult GMO (NGT)-varsel",
   "gmoFishAlert": "GMO-fôr (Fisk)",
   "highRisk": "HØY RISIKO",
   "possibleRisk": "MULIG RISIKO",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,8 @@ import 'ad_helper.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'config/links.dart';
 import 'services/remote_risk_rules_service.dart';
+import 'data/ngt_risk_brands.dart';
+import 'services/remote_ngt_suppliers_service.dart';
 
 // --- DEFINISJON AV RISIKO ---
 const List<String> bovaerRedBrands = ['arla', 'apetina', 'aptina'];
@@ -239,12 +241,14 @@ class _ScannerScreenState extends State<ScannerScreen>
   bool varselBovaer = true;
   bool varselInsekt = true;
   bool varselGmo = true;
+  bool varselNgt = true;
   bool wakeLockOn = false;
   bool premiumActive = false;
   String selectedLanguage = 'nb'; // Default til norsk
   String selectedCountry = 'NO'; // Default til Norge
   bool _initialPrivacyDialogOpen = false;
   Map<String, Map<String, List<String>>> _remoteRiskRulesByCountry = {};
+  List<NgtSupplierEntry> _ngtSuppliers = [];
 
   BannerAd? _bannerAd;
   bool _bannerAdLoaded = false;
@@ -270,6 +274,7 @@ class _ScannerScreenState extends State<ScannerScreen>
     }
     if (!_isTestEnv) {
       _loadRemoteRiskRules();
+      _loadRemoteNgtSuppliers();
     }
     _loadBannerAd();
   }
@@ -395,6 +400,7 @@ class _ScannerScreenState extends State<ScannerScreen>
     varselBovaer = innstillingerBox.get('varselBovaer', defaultValue: true);
     varselGmo = innstillingerBox.get('varselGmo', defaultValue: true);
     varselInsekt = innstillingerBox.get('varselInsekt', defaultValue: true);
+    varselNgt = innstillingerBox.get('varselNgt', defaultValue: true);
     wakeLockOn = innstillingerBox.get('wakeLockOn', defaultValue: false);
     selectedLanguage =
         innstillingerBox.get('selectedLanguage', defaultValue: 'nb');
@@ -453,6 +459,32 @@ class _ScannerScreenState extends State<ScannerScreen>
       });
     } catch (_) {
       // Keep cached/local fallback when remote fetch fails.
+    }
+  }
+
+  /// Loads the human-approved NGT supplier list. Reads cache instantly, then
+  /// refreshes in the background (once per day). Approved entries reach the
+  /// app without a new release.
+  Future<void> _loadRemoteNgtSuppliers() async {
+    final service = RemoteNgtSuppliersService(innstillingerBox);
+
+    final cached = service.readCached();
+    if (cached.isNotEmpty && mounted) {
+      setState(() {
+        _ngtSuppliers = cached;
+      });
+    }
+
+    if (!service.isStale()) return;
+
+    try {
+      final fetched = await service.fetchAndCache();
+      if (!mounted) return;
+      setState(() {
+        _ngtSuppliers = fetched;
+      });
+    } catch (_) {
+      // Keep cached/empty fallback when remote fetch fails.
     }
   }
 
@@ -906,6 +938,14 @@ class _ScannerScreenState extends State<ScannerScreen>
               insectAssessment['consumerRisk'] as RiskLevel;
             info['insectConsumerText'] =
               (insectAssessment['consumerText'] ?? '').toString();
+
+          final ngtAssessment = _analyzeNgtRisk(
+            info['merke']!,
+            info['etiketter']!,
+          );
+          info['ngtRisk'] = ngtAssessment['risk'] as RiskLevel;
+          info['ngtRiskText'] = (ngtAssessment['text'] ?? '').toString();
+          info['ngtRiskUrl'] = (ngtAssessment['url'] ?? '').toString();
           return info;
         }
       }
@@ -1141,6 +1181,15 @@ class _ScannerScreenState extends State<ScannerScreen>
                           onChanged: (v) {
                             setDialogState(() => varselInsekt = v);
                             innstillingerBox.put('varselInsekt', v);
+                          }),
+                      SwitchListTile(
+                          title: Text(
+                              AppLocalizations.of(context)?.ngtAlert ??
+                                  'Hidden GMO (NGT) Alert'),
+                          value: varselNgt,
+                          onChanged: (v) {
+                            setDialogState(() => varselNgt = v);
+                            innstillingerBox.put('varselNgt', v);
                           }),
                     ]),
                     actions: [
@@ -1856,6 +1905,82 @@ class _ScannerScreenState extends State<ScannerScreen>
       'consumerText': '',
       'url': '',
     };
+  }
+
+  /// "Skjult GMO" / NGT precaution.
+  ///
+  /// Legally framed as a YELLOW "MULIG RISIKO" (risk of) signal, never red and
+  /// never an assertion that the product contains gene-edited ingredients.
+  /// YELLOW is shown ONLY for producers/retailers where it is documented that
+  /// they have purchased and received deliveries from a GMO/NGT industry
+  /// (curated list). There is NO automatic crop- or retailer-size heuristic.
+  Map<String, dynamic> _analyzeNgtRisk(String brand, String labels) {
+    if (!varselNgt) {
+      return {'risk': RiskLevel.unknown, 'text': '', 'url': ''};
+    }
+
+    final lowerBrand = brand.toLowerCase();
+    final lowerLabels = labels.toLowerCase();
+
+    final country =
+        (selectedCountry.isEmpty ? _defaultCountryCode() : selectedCountry)
+            .toUpperCase();
+    final greens =
+        _countryRulesList(country, 'organic_keywords', greenKeywords);
+
+    final locale =
+        (AppLocalizations.of(context)?.localeName ?? selectedLanguage)
+            .toLowerCase();
+    final isNorwegian = locale == 'nb';
+
+    // Certified organic excludes GMO/NGT by definition — green.
+    if (greens.any((k) => lowerLabels.contains(k.toLowerCase()))) {
+      return {'risk': RiskLevel.green, 'text': '', 'url': ''};
+    }
+
+    // Never flag a traditional / small-scale producer or farm shop — green.
+    if (ngtTraditionalExclusions.any(lowerBrand.contains)) {
+      return {'risk': RiskLevel.green, 'text': '', 'url': ''};
+    }
+
+    // YELLOW is shown ONLY for producers/retailers where it is documented that
+    // they have purchased and received deliveries from a GMO/NGT industry.
+    // There is NO automatic heuristic based on crops or retailer size — an
+    // actor only lands on the yellow side once such sourcing is verified and
+    // added to the approved list. Everything else is green.
+    //
+    // Source 1 (preferred): remote, human-approved list (matsjekk.com).
+    // Updates here reach the app within a day, without a new release.
+    for (final entry in _ngtSuppliers) {
+      if (entry.brandAliases.any(lowerBrand.contains)) {
+        final reason = isNorwegian ? entry.reasonNb : entry.reasonEn;
+        return {
+          'risk': RiskLevel.yellow,
+          'text': reason.trim().isNotEmpty
+              ? reason
+              : (isNorwegian
+                  ? 'MULIG RISIKO: Dokumentert leveranse fra kjent GMO-leverandør.'
+                  : 'POSSIBLE RISK: Documented sourcing from a known GMO supplier.'),
+          'url': entry.sourceUrl.trim().isNotEmpty
+              ? entry.sourceUrl
+              : kEditorialMethodUrl,
+        };
+      }
+    }
+
+    // Source 2 (fallback): local curated list shipped with the app.
+    for (final entry in ngtRiskBrands.entries) {
+      if (entry.key.isNotEmpty && lowerBrand.contains(entry.key)) {
+        return {
+          'risk': RiskLevel.yellow,
+          'text': isNorwegian ? entry.value.reasonNb : entry.value.reasonEn,
+          'url': kEditorialMethodUrl,
+        };
+      }
+    }
+
+    // Default: green unless documented otherwise.
+    return {'risk': RiskLevel.green, 'text': '', 'url': ''};
   }
 
   List<String> _parseEStoffer(String ingredients) {

--- a/lib/services/remote_ngt_suppliers_service.dart
+++ b/lib/services/remote_ngt_suppliers_service.dart
@@ -1,0 +1,109 @@
+import 'dart:convert';
+
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:http/http.dart' as http;
+
+import '../config/links.dart';
+
+/// One human-approved supplier entry: a brand documented to source from a
+/// known GMO supplier. Shown in the app as a YELLOW "MULIG RISIKO" signal.
+class NgtSupplierEntry {
+  /// Lowercase brand substrings matched against the product brand name.
+  final List<String> brandAliases;
+  final String reasonNb;
+  final String reasonEn;
+  final String sourceUrl;
+
+  const NgtSupplierEntry({
+    required this.brandAliases,
+    required this.reasonNb,
+    required this.reasonEn,
+    required this.sourceUrl,
+  });
+
+  factory NgtSupplierEntry.fromJson(Map<String, dynamic> json) {
+    final aliasesRaw = json['brand_aliases'];
+    final aliases = aliasesRaw is List
+        ? aliasesRaw
+            .map((e) => e.toString().trim().toLowerCase())
+            .where((e) => e.isNotEmpty)
+            .toList()
+        : <String>[];
+    return NgtSupplierEntry(
+      brandAliases: aliases,
+      reasonNb: (json['reason_nb'] ?? '').toString(),
+      reasonEn: (json['reason_en'] ?? '').toString(),
+      sourceUrl: (json['source_url'] ?? '').toString(),
+    );
+  }
+}
+
+/// Fetches and caches the human-approved NGT supplier list published at
+/// [kNgtSuppliersUrl]. Approved entries reach the app without a new release.
+///
+/// Cache strategy mirrors [RemoteRiskRulesService]: read cache instantly,
+/// refresh in the background (once per day is enough — the list changes rarely).
+class RemoteNgtSuppliersService {
+  static const String _cacheKey = 'remote_ngt_suppliers_cache_v1';
+  static const String _cacheTimestampKey = 'remote_ngt_suppliers_cache_ts_v1';
+
+  final Box settingsBox;
+
+  RemoteNgtSuppliersService(this.settingsBox);
+
+  List<NgtSupplierEntry> readCached() {
+    final raw = settingsBox.get(_cacheKey);
+    if (raw is! String || raw.isEmpty) {
+      return const [];
+    }
+    try {
+      return _parse(json.decode(raw));
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  /// True when the cache is older than [maxAge] (or missing).
+  bool isStale({Duration maxAge = const Duration(hours: 24)}) {
+    final ts = settingsBox.get(_cacheTimestampKey);
+    if (ts is! String || ts.isEmpty) return true;
+    final parsed = DateTime.tryParse(ts);
+    if (parsed == null) return true;
+    return DateTime.now().difference(parsed) > maxAge;
+  }
+
+  Future<List<NgtSupplierEntry>> fetchAndCache() async {
+    final response = await http
+        .get(Uri.parse(kNgtSuppliersUrl))
+        .timeout(const Duration(seconds: 8));
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to fetch NGT suppliers: ${response.statusCode}');
+    }
+
+    final decoded = json.decode(response.body);
+    final entries = _parse(decoded);
+
+    await settingsBox.put(_cacheKey, response.body);
+    await settingsBox.put(
+        _cacheTimestampKey, DateTime.now().toIso8601String());
+    return entries;
+  }
+
+  static List<NgtSupplierEntry> _parse(dynamic decoded) {
+    if (decoded is! Map) return const [];
+    final list = decoded['suppliers'];
+    if (list is! List) return const [];
+    final result = <NgtSupplierEntry>[];
+    for (final item in list) {
+      if (item is Map) {
+        final entry =
+            NgtSupplierEntry.fromJson(item.cast<String, dynamic>());
+        if (entry.brandAliases.isNotEmpty) {
+          result.add(entry);
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -1270,6 +1270,7 @@ class _HandlelisteOverlayState extends State<HandlelisteOverlay> {
                                         'List is empty'));
                           }
                           return ReorderableListView(
+                            // ignore: deprecated_member_use
                             onReorder: (oldIndex, newIndex) {
                               if (newIndex > oldIndex) newIndex--;
                               final item = varer.removeAt(oldIndex);

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -347,6 +347,7 @@ class _ProductInfoDialogContentState extends State<ProductInfoDialogContent> {
     final bovaerRiskUrl = (info['bovaerRiskUrl'] as String? ?? '').trim();
     final gmoRiskUrl = (info['gmoRiskUrl'] as String? ?? '').trim();
     final insectRiskUrl = (info['insectRiskUrl'] as String? ?? '').trim();
+    final ngtRiskUrl = (info['ngtRiskUrl'] as String? ?? '').trim();
 
     bool isRedOrYellow(dynamic value) =>
         value == RiskLevel.red || value == RiskLevel.yellow;
@@ -356,7 +357,8 @@ class _ProductInfoDialogContentState extends State<ProductInfoDialogContent> {
         isRedOrYellow(info['gmoRegulatoryRisk']) ||
         isRedOrYellow(info['insectConsumerRisk']) ||
         isRedOrYellow(info['insectRisk']) ||
-        isRedOrYellow(info['insectRegulatoryRisk']);
+        isRedOrYellow(info['insectRegulatoryRisk']) ||
+        isRedOrYellow(info['ngtRisk']);
 
     return SizedBox(
         width: double.maxFinite,
@@ -447,6 +449,20 @@ class _ProductInfoDialogContentState extends State<ProductInfoDialogContent> {
                         context,
                         insectRiskUrl,
                         'Open insect source',
+                      ),
+                    _buildRiskWidget(
+                      context,
+                      'Skjult GMO (NGT)',
+                      info['ngtRisk'] as RiskLevel? ?? RiskLevel.unknown,
+                      customText: (info['ngtRiskText'] ?? '').toString(),
+                    ),
+                    if (ngtRiskUrl.isNotEmpty &&
+                        (info['ngtRisk'] == RiskLevel.red ||
+                            info['ngtRisk'] == RiskLevel.yellow))
+                      _sourceLinkButton(
+                        context,
+                        ngtRiskUrl,
+                        'See updated status',
                       ),
                     // Metodikk-banner: forklarer føre-var/spredningskjede.
                     const SizedBox(height: 8),

--- a/scripts/ngt_monitor.py
+++ b/scripts/ngt_monitor.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+NGT / hidden-GMO supplier monitor (simple starter).
+
+Goal
+----
+Watch a small set of producers/retailers and flag one ONLY when a source
+documents a link between that actor and a KNOWN GMO supplier (companies with
+Monsanto/Bayer-type agreements). The monitor produces PROPOSALS for human
+review — it never publishes anything to the app on its own.
+
+How it works (deliberately simple to start)
+-------------------------------------------
+1. Read config (known GMO suppliers, watch actors, sources).
+2. Fetch each enabled source's text.
+3. If a watched actor AND a known GMO supplier are mentioned in the same
+   source, emit a proposal with the source URL + the surrounding snippet.
+4. Write all proposals to scripts/ngt_proposals.json.
+
+A human then reviews ngt_proposals.json (e.g. in the PR opened by the
+workflow) and, if verified, promotes the entry into the published list
+docs/data/ngt_suppliers.json. Only then does the app show a yellow signal.
+
+Optional LLM refinement
+-----------------------
+If the environment variable OPENAI_API_KEY is set, an optional refinement step
+can be added later. The default path uses no external API and no API key, so it
+is free and deterministic.
+
+Usage
+-----
+    python scripts/ngt_monitor.py
+    python scripts/ngt_monitor.py --config scripts/ngt_monitor_config.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CONFIG = Path(__file__).resolve().parent / "ngt_monitor_config.json"
+PROPOSALS_PATH = Path(__file__).resolve().parent / "ngt_proposals.json"
+
+SNIPPET_RADIUS = 200  # characters of context around a match
+HTTP_TIMEOUT = 15
+USER_AGENT = "MatsjekkNGTMonitor/1.0 (+https://matsjekk.com)"
+
+
+def load_config(path: Path) -> dict:
+    if not path.exists():
+        print(f"ERROR: config not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def fetch_text(url: str) -> str:
+    """Fetch a URL and return plain-ish text (HTML tags stripped)."""
+    req = Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+        charset = resp.headers.get_content_charset() or "utf-8"
+        raw = resp.read().decode(charset, errors="replace")
+    # Strip scripts/styles then tags.
+    raw = re.sub(r"<(script|style)[^>]*>.*?</\1>", " ", raw, flags=re.I | re.S)
+    text = re.sub(r"<[^>]+>", " ", raw)
+    text = re.sub(r"\s+", " ", text)
+    return text
+
+
+def find_aliases(text_lower: str, group: list[dict]) -> list[tuple[str, str, int]]:
+    """Return list of (canonical_name, matched_alias, index) for the group."""
+    hits: list[tuple[str, str, int]] = []
+    for item in group:
+        name = item.get("name", "")
+        for alias in item.get("aliases", []):
+            a = alias.strip().lower()
+            if not a:
+                continue
+            idx = text_lower.find(a)
+            if idx != -1:
+                hits.append((name, alias, idx))
+                break  # one hit per item is enough
+    return hits
+
+
+def make_snippet(text: str, index: int) -> str:
+    start = max(0, index - SNIPPET_RADIUS)
+    end = min(len(text), index + SNIPPET_RADIUS)
+    snippet = text[start:end].strip()
+    return ("..." if start > 0 else "") + snippet + ("..." if end < len(text) else "")
+
+
+def analyze_source(source: dict, suppliers: list[dict], actors: list[dict]) -> list[dict]:
+    url = source.get("url", "")
+    name = source.get("name", url)
+    try:
+        text = fetch_text(url)
+    except (URLError, HTTPError, ValueError, TimeoutError) as exc:
+        print(f"  WARN: could not fetch {url}: {exc}", file=sys.stderr)
+        return []
+
+    text_lower = text.lower()
+    actor_hits = find_aliases(text_lower, actors)
+    supplier_hits = find_aliases(text_lower, suppliers)
+
+    if not actor_hits or not supplier_hits:
+        return []
+
+    proposals: list[dict] = []
+    for actor_name, actor_alias, actor_idx in actor_hits:
+        for supplier_name, supplier_alias, _supplier_idx in supplier_hits:
+            proposals.append(
+                {
+                    "actor": actor_name,
+                    "matched_actor_alias": actor_alias,
+                    "gmo_supplier": supplier_name,
+                    "matched_supplier_alias": supplier_alias,
+                    "source_name": name,
+                    "source_url": url,
+                    "snippet": make_snippet(text, actor_idx),
+                    "detected_at": datetime.now(timezone.utc).isoformat(),
+                    "confidence": "low",
+                    "status": "needs_review",
+                    "note": "Co-occurrence in the same source. VERIFY the source manually before promoting.",
+                }
+            )
+    return proposals
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="NGT/hidden-GMO supplier monitor")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--out", type=Path, default=PROPOSALS_PATH)
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    suppliers = config.get("known_gmo_suppliers", [])
+    actors = config.get("watch_actors", [])
+    sources = [s for s in config.get("sources", []) if s.get("enabled")]
+
+    if not sources:
+        print("No enabled sources in config. Add real source URLs and set "
+              '"enabled": true to start monitoring.')
+        # Still write an empty proposals file so downstream steps are stable.
+        args.out.write_text(
+            json.dumps(
+                {
+                    "generated_at": datetime.now(timezone.utc).isoformat(),
+                    "proposals": [],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return 0
+
+    all_proposals: list[dict] = []
+    for source in sources:
+        print(f"Scanning: {source.get('name', source.get('url'))}")
+        all_proposals.extend(analyze_source(source, suppliers, actors))
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "proposal_count": len(all_proposals),
+        "proposals": all_proposals,
+    }
+    args.out.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"\nWrote {len(all_proposals)} proposal(s) to {args.out}")
+    print("NOTE: these are PROPOSALS only. A human must verify each source and "
+          "promote it into docs/data/ngt_suppliers.json before the app shows it.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ngt_monitor_config.json
+++ b/scripts/ngt_monitor_config.json
@@ -1,0 +1,59 @@
+{
+  "_comment": "Config for the NGT/hidden-GMO supplier monitor. Keep it simple. The monitor flags a watched actor ONLY when a source documents a link between that actor and a known GMO supplier (companies with Monsanto/Bayer-type agreements). A human approves every proposal before it reaches the app.",
+
+  "known_gmo_suppliers": [
+    {
+      "name": "Bayer Crop Science",
+      "aliases": ["bayer crop science", "bayer cropscience", "monsanto", "bayer"]
+    },
+    {
+      "name": "Corteva Agriscience",
+      "aliases": ["corteva", "dow agrosciences", "dupont pioneer", "pioneer hi-bred"]
+    },
+    {
+      "name": "Syngenta",
+      "aliases": ["syngenta", "chemchina"]
+    },
+    {
+      "name": "BASF Agricultural Solutions",
+      "aliases": ["basf agricultural", "basf seeds"]
+    },
+    {
+      "name": "Cargill",
+      "aliases": ["cargill"]
+    },
+    {
+      "name": "Archer Daniels Midland",
+      "aliases": ["archer daniels midland", "adm "]
+    },
+    {
+      "name": "Bunge",
+      "aliases": ["bunge"]
+    }
+  ],
+
+  "watch_actors": [
+    { "name": "NorgesGruppen", "aliases": ["norgesgruppen", "first price", "eldorado", "kiwi", "meny", "spar", "joker"] },
+    { "name": "Coop Norge", "aliases": ["coop norge", "coop obs", "extra", "x-tra", "coop mega"] },
+    { "name": "Rema 1000", "aliases": ["rema 1000", "rema1000"] },
+    { "name": "Orkla", "aliases": ["orkla"] }
+  ],
+
+  "sources": [
+    {
+      "name": "GMWatch - latest news",
+      "url": "https://www.gmwatch.org/en/106-news/latest-news",
+      "enabled": true
+    },
+    {
+      "name": "Example press-release page (replace with real URLs)",
+      "url": "https://example.com/press",
+      "enabled": false
+    }
+  ],
+
+  "settings": {
+    "min_confidence": "low",
+    "note": "Detection is deterministic co-occurrence (an actor and a known GMO supplier mentioned in the same source). This produces PROPOSALS only — never auto-publishes."
+  }
+}


### PR DESCRIPTION
Ren re-applisering av NGT-funksjonen rett paa toppen av dagens main. Erstatter PR #62, som hadde divergert 454 commits fra main og var umulig aa merge.

## Hva
- **Ny NGT / 'Skjult GMO' risikokategori** ved produktoppslag: alltid GUL 'MULIG RISIKO', aldri rod, og aldri en paastand om at produktet *inneholder* genredigerte ingredienser. Juridisk trygg formulering i 'risiko for'-registeret.
- **Streng logikk:** GUL vises KUN for produsenter/forhandlere der det er dokumentert at de har handlet og mottatt leveranse fra en kjent GMO-/NGT-leverandor (kuratert/godkjent liste). Ingen automatisk crop- eller kjede-storrelse-heuristikk. Tradisjonelle/smaaskala-produsenter og okologisk er alltid GRONN.
- **Fjernstyrt godkjent liste** (docs/data/ngt_suppliers.json) leses 1x/dogn -> godkjente oppforinger naar alle apper innen ~24t **uten ny app-versjon**.
- **AI-monitor** (scripts/ngt_monitor.py + .github/workflows/ngt-monitor.yml, ukentlig cron) foreslaar kandidater fra GMWatch m.fl. og aapner PR for **manuell godkjenning** - publiserer aldri selv.

## Filer
Nye: lib/data/ngt_risk_brands.dart, lib/services/remote_ngt_suppliers_service.dart, docs/data/ngt_suppliers.json, scripts/ngt_monitor.py, scripts/ngt_monitor_config.json, .github/workflows/ngt-monitor.yml.
Endret: lib/main.dart (analyzer + state + innlasting + innstilling), lib/widgets.dart (risiko-widget), lib/config/links.dart (URL-er), lib/l10n + lib/gen_l10n (ngtAlert i 11+ sprak).

## Kvalitet
- flutter analyze lib test -> No issues found!
- flutter test -> alle 23 tester gronne.
- Ingen hemmeligheter i diff (kassalapp.token ikke inkludert).

## Merk
Naar denne merges til main vil deploy_docs publisere docs/data/ngt_suppliers.json til matsjekk.com, slik at fjernoppdaterings-mekanismen blir aktiv.